### PR TITLE
createLogger import fix

### DIFF
--- a/docs/advanced/AsyncActions.md
+++ b/docs/advanced/AsyncActions.md
@@ -394,7 +394,7 @@ export function fetchPosts(subreddit) {
 
 ```js
 import thunkMiddleware from 'redux-thunk'
-import createLogger from 'redux-logger'
+import { createLogger } from 'redux-logger'
 import { createStore, applyMiddleware } from 'redux'
 import { selectSubreddit, fetchPosts } from './actions'
 import rootReducer from './reducers'


### PR DESCRIPTION
Если импортировать import createLogger то applyMiddleware ругается 
Uncaught TypeError: middleware is not a function

Правильный вариант импорта: import { createLogger } from 'redux-logger';